### PR TITLE
Only update currentPage if ScrollNotification is PageMetrics change

### DIFF
--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -110,7 +110,7 @@ class PageContainerState extends State<PageIndicatorContainer> {
   PageView get pageView => widget.child;
 
   bool _onScroll(ScrollNotification notification) {
-    if (notification is ScrollUpdateNotification) {
+    if (notification.metrics is PageMetrics) {
       final PageMetrics metrics = notification.metrics;
       currentPage = metrics.page;
       setState(() {});


### PR DESCRIPTION
Currently an error is thrown if a scroll on the PageView is a FixedScrollMetrics rather than a PageMetrics change.

`The following assertion was thrown while handling a gesture:`
`'FixedScrollMetrics' is not a subtype of type 'PageMetrics'`

https://github.com/flutter/flutter/issues/40518